### PR TITLE
Added GPDB scripts needed by AMI preparation for AWS Cloudformation

### DIFF
--- a/bootstrap-scripts/After_AMI_creation/directory_setup.sh
+++ b/bootstrap-scripts/After_AMI_creation/directory_setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Prerequisite: a password-less sudo account
+
+# Display command before executing
+
+if [ ${MY_INTERNAL_IP} != ${MASTER_IP} ] || [ ${MY_INTERNAL_IP} != ${STANDBY_MASTER_IP} ]; then
+	echo "This is not a master or standby master node"
+	for DATADIR in /data*; do
+		mkdir -p ${DATADIR}/primary
+		mkdir -p ${DATADIR}/mirror
+	done
+fi
+
+if [ ${MY_INTERNAL_IP} == ${MASTER_IP} ] || [ ${MY_INTERNAL_IP} == ${STANDBY_MASTER_IP} ]; then
+	echo "This is a master or standby master node"
+	mkdir -p /data1/master
+fi
+
+chown gpadmin:gpadmin -R /data*/*

--- a/bootstrap-scripts/After_AMI_creation/gpadmin_bashrc_setup.sh
+++ b/bootstrap-scripts/After_AMI_creation/gpadmin_bashrc_setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Prerequisite: a password-less sudo account
+
+# Display command before executing
+set -o xtrace
+
+if [ ${MY_INTERNAL_IP} == ${MASTER_IP} ] || [ ${MY_INTERNAL_IP} == ${STANDBY_MASTER_IP} ]; then
+	echo "export MASTER_DATA_DIRECTORY=${MASTER_DATA_DIRECTORY}" >> /home/gpadmin/.bashrc
+fi
+echo "source /usr/local/greenplum-db/greenplum_path.sh" >> /home/gpadmin/.bashrc
+echo "export GPPERFMONHOME=/usr/local/greenplum-cc-web" >> /home/gpadmin/.bashrc
+echo "source \$GPPERFMONHOME/gpcc_path.sh" >> /home/gpadmin/.bashrc

--- a/bootstrap-scripts/After_AMI_creation/gpadmin_user_setup.sh
+++ b/bootstrap-scripts/After_AMI_creation/gpadmin_user_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+##############################################
+# Prerequisite: a password-less sudo account #
+##############################################
+
+# Display command before executing
+set -o xtrace
+
+echo "Creating use gpadmin"
+# Add user gpadmin with password gpadmin
+password=gpadmin
+getent passwd gpadmin || useradd -m gpadmin
+passwd gpadmin << EOF
+$password
+$password
+EOF

--- a/bootstrap-scripts/After_AMI_creation/gpcc_init.sh
+++ b/bootstrap-scripts/After_AMI_creation/gpcc_init.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Prerequisite: a password-less sudo account
+
+# Display command before executing
+set -o xtrace
+
+echo "Installing gpperfmon"
+
+echo "Updating pg_hba"
+
+if [[ $(hostname) == "mdw" ]]; then
+	su gpadmin -l -c "gpperfmon_install --enable --password pivotal --port 5432"
+	echo "local   gpperfmon         gpmon         md5" >> ${MASTER_DATA_DIRECTORY}/pg_hba.conf
+	echo "host    gpperfmon      gpmon        127.0.0.1/28       md5" >> ${MASTER_DATA_DIRECTORY}/pg_hba.conf
+	# if [[ -n "$STANDBY" ]] && [[ "$STANDBY" -ge 1 ]]; then
+	echo "Copying over .pgpass file to smdw"
+	su gpadmin -c "scp ${MASTER_DATA_DIRECTORY}/pg_hba.conf smdw:${MASTER_DATA_DIRECTORY}/pg_hba.conf"
+	su gpadmin -c "scp ~/.pgpass smdw:~gpadmin/.pgpass"
+	# fi
+	echo "Restarting gpdb"
+	su gpadmin -l -c "gpstop -a -r"
+fi
+
+echo "Initialize GPCC"
+
+# if [[ "$STANDBY" -ge 1 ]]; then
+# 	#su gpadmin -l -c  'source /usr/local/greenplum-db/greenplum_path.sh; echo -e "GPDB\nn\nGPDB\n\n\n\nn\nn\nn\ny\nsmdw\n" | gpcmdr --setup' || [[ $? == 255 ]]
+su gpadmin -l -c  'source /usr/local/greenplum-db/greenplum_path.sh; echo -e "GPDB\nn\nGPDB\n\n\n\n\n\n\n\nsmdw\n" | gpcmdr --setup' || [[ $? == 255 ]]
+# else
+# 	#su gpadmin -l -c 'source /usr/local/greenplum-db/greenplum_path.sh; echo -e "GPDB\nn\nGPDB\n\n\n\nn\nn\nn\nn" | gpcmdr --setup' || [[ $? == 255 ]]
+# 	su gpadmin -l -c 'source /usr/local/greenplum-db/greenplum_path.sh; echo -e "GPDB\nn\nGPDB\n\n\n\n\n\n\nn\n" | gpcmdr --setup' || [[ $? == 255 ]]
+# fi
+su gpadmin -l -c 'source /usr/local/greenplum-db/greenplum_path.sh; echo -e "y\n" | gpcmdr --start'

--- a/bootstrap-scripts/After_AMI_creation/gpcc_install.sh
+++ b/bootstrap-scripts/After_AMI_creation/gpcc_install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+##############################################
+# Prerequisite: a password-less sudo account #
+##############################################
+
+# Display command before executing
+set -o xtrace
+
+echo "Running GPDB Comand Center installer"
+unzip greenplum-cc*.zip
+
+GREENPLUM_CC=`find . -name greenplum-cc*.bin`
+chmod a+x ${GREENPLUM_CC}
+echo -e "yes\n\nyes\nyes\n" | MORE=-1000 sh ${GREENPLUM_CC}
+chown -R gpadmin:gpadmin /usr/local/greenplum-cc-web*
+chmod -R 777 /usr/local/greenplum-cc-web*

--- a/bootstrap-scripts/After_AMI_creation/gpdb_init.sh
+++ b/bootstrap-scripts/After_AMI_creation/gpdb_init.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Prerequisite: a password-less sudo account
+
+# Display command before executing
+set -o xtrace
+
+echo "Preparing /home/gpadmin/gpconfigs"
+
+mkdir -p /home/gpadmin/gpconfigs
+cp /usr/local/greenplum-db/docs/cli_help/gpconfigs/gpinitsystem_config /home/gpadmin/gpconfigs/
+echo "$SEGMENT_HOSTS" > /home/gpadmin/gpconfigs/hostfile_gpinitsystem
+
+chown gpadmin:gpadmin -R /home/gpadmin/gpconfigs
+
+sed -i -r "s/#MACHINE_LIST_FILE/MACHINE_LIST_FILE/" /home/gpadmin/gpconfigs/gpinitsystem_config
+
+sed -i -r "s/#MIRROR_PORT_BASE/MIRROR_PORT_BASE/" /home/gpadmin/gpconfigs/gpinitsystem_config
+sed -i -r "s/#REPLICATION_PORT_BASE/REPLICATION_PORT_BASE/" /home/gpadmin/gpconfigs/gpinitsystem_config
+sed -i -r "s/#MIRROR_REPLICATION_PORT_BASE/MIRROR_REPLICATION_PORT_BASE/" /home/gpadmin/gpconfigs/gpinitsystem_config
+sed -i -r "s/#declare -a MIRROR_DATA_DIRECTORY/declare -a MIRROR_DATA_DIRECTORY/" /home/gpadmin/gpconfigs/gpinitsystem_config
+
+sed -i -r "s| DATA_DIRECTORY=\(.*\)| DATA_DIRECTORY\=\(${DATA_DIRECTORY}\)|" /home/gpadmin/gpconfigs/gpinitsystem_config
+sed -i -r "s| MIRROR_DATA_DIRECTORY=\(.*\)| MIRROR_DATA_DIRECTORY\=\(${MIRROR_DATA_DIRECTORY}\)|" /home/gpadmin/gpconfigs/gpinitsystem_config
+
+sed -i -r "s|MASTER_DIRECTORY=/data/master|MASTER_DIRECTORY=${MASTER_DIRECTORY}|" /home/gpadmin/gpconfigs/gpinitsystem_config
+echo "Running gpinitsystem"
+
+if [ -z "$STANDBY_MASTER_IP" ]; then
+	echo "No standby master specified..."
+	echo | su - gpadmin -c "bash -c 'gpinitsystem -a -c /home/gpadmin/gpconfigs/gpinitsystem_config'" || [[ $? -lt 2 ]]
+else
+	echo "Standby master specified IP=$STANDBY_MASTER_IP HOST=$STANDBY_MASTER_HOST"
+	echo | su - gpadmin -c "bash -c 'gpinitsystem -a -c /home/gpadmin/gpconfigs/gpinitsystem_config -s smdw'" || [[ $? -lt 2 ]]
+fi

--- a/bootstrap-scripts/After_AMI_creation/gpdb_optimize.sh
+++ b/bootstrap-scripts/After_AMI_creation/gpdb_optimize.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Prerequisite: a password-less sudo account
+
+# Display command before executing
+set -o xtrace
+
+SEGMENTS=$1
+MASTER_DATA_DIRECTORY=$2
+
+echo "Adding ETL hosts to pg_hba.conf"
+for IP in $INTERNAL_ETL_IPS; do
+  echo -e "host\tall\tgpadmin\t${IP}/32\ttrust" >> "${MASTER_DATA_DIRECTORY}/pg_hba.conf"
+done
+
+if [[ $(hostname) == "smdw" ]]; then
+  exit
+fi
+
+echo "Setting GUCS for ${SEGMENTS} segments"
+
+gpconfig -c optimizer -v on
+
+CORES=$(cat /proc/cpuinfo | grep -c processor)
+CORES_PER_SEGMENT=$(bc <<< "scale=2; ${CORES}/${SEGMENTS}")
+gpconfig -c gp_resqueue_priority_cpucores_per_segment -v ${CORES_PER_SEGMENT} -m ${CORES}
+
+RAM=$(free -g | grep Mem | xargs | cut -f2 -d' ')
+if [[ $RAM -ge 128 ]]; then
+  AV_RAM=$(( $RAM - 32 ))
+else
+  AV_RAM=$(( $RAM - 16 ))
+fi
+RAM_PER_SEGMENT=$(( $AV_RAM / $SEGMENTS ))
+RAM_PER_SEGMENT_KB=$(( $RAM_PER_SEGMENT * 1024 * 1024 ))
+
+gpconfig -c gp_vmem_protect_limit -v ${RAM_PER_SEGMENT_KB}
+gpconfig -c max_statement_mem -v ${RAM_PER_SEGMENT}GB
+
+echo "Reloading database"
+gpstop -a -r

--- a/bootstrap-scripts/After_AMI_creation/hosts_update.sh
+++ b/bootstrap-scripts/After_AMI_creation/hosts_update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Prerequisite: a password-less sudo account
+
+# Display command before executing
+
+echo "generating ip host mapping file ${IP_HOSTS_MAPPING}"
+awk '{if (NR==1) {printf "%s mdw\n",$0} else if (NR==2) {printf "%s smdw\n",$0} else printf "%s sdw%d\n",$0,NR-2}' ${INTERNAL_IP_FILE} > ${IP_HOSTS_MAPPING}
+cat ${IP_HOSTS_MAPPING} | cut -d" " -f2 > ${HOSTNAME_FILE}
+
+# Update /etc/hosts
+echo "Updating /etc/hosts"
+HOSTFILE_HEAD="# BEGIN GENERATED CONTENT"
+HOSTFILE_TAIL="# END GENERATED CONTENT"
+sed -i -e "/$HOSTFILE_HEAD/,/$HOSTFILE_TAIL/d" /etc/hosts
+echo "$HOSTFILE_HEAD" >> /etc/hosts
+cat "${IP_HOSTS_MAPPING}" >> /etc/hosts
+echo "$HOSTFILE_TAIL" >> /etc/hosts
+
+while IFS= read -r line; do
+	IFS=' ' read -r -a array <<< "$line"
+	if [  "${array[0]}" = "$MY_INTERNAL_IP" ]; then
+		echo -e "\e[33m*** Updating hostname of ${array[0]} to ${array[1]} ***\e[0m"
+		hostname ${array[1]}
+		echo "Testing..."
+		echo -e "\e[32m`hostname`\e[0m"
+		echo -e "\e[33m*** Updating /etc/sysconfig/network of ${array[1]}(${array[0]}) ***\e[0m"
+		printf '%s\n%s\n%s\n%s\n' 'NETWORKING=yes' 'NETWORKING_IPV6=no' "HOSTNAME=`hostname --fqdn`" 'NOZEROCONF=yes' > /etc/sysconfig/network
+		echo "Testing..."
+		echo -e "\e[32m`cat /etc/sysconfig/network`\e[0m"
+    fi
+done < ${IP_HOSTS_MAPPING}

--- a/bootstrap-scripts/After_AMI_creation/linux_storage_setup.sh
+++ b/bootstrap-scripts/After_AMI_creation/linux_storage_setup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+##############################################
+# Prerequisite: a password-less sudo account #
+##############################################
+
+# display command before executing
+set -o xtrace
+
+READAHEAD="/sbin/blockdev --setra 16384 /dev/xvd[a-z]"
+
+FSTAB_HEAD="# BEGIN GENERATED CONTENT"
+FSTAB_TAIL="# END GENERATED CONTENT"
+
+if [[ -z $DRIVE_PATTERN ]]; then
+  DRIVE_PATTERN="/dev/xvd[b-z]"
+fi
+
+main() {
+  echo Storage
+
+  set_readahead
+
+  calculate_volumes
+
+  create_volumes
+}
+
+set_readahead() {
+  $READAHEAD
+  echo "$READAHEAD" >> /etc/rc.local
+}
+
+calculate_volumes() {
+  DRIVES=($(ls $DRIVE_PATTERN))
+  DRIVE_COUNT=${#DRIVES[@]}
+
+  if [[ -z "${VOLUMES}" ]]; then
+    if [[ $DRIVE_COUNT -lt 8 ]]; then
+      VOLUMES=1
+    elif [[ $DRIVE_COUNT -lt 12 ]]; then
+      VOLUMES=2
+    else
+      VOLUMES=4
+    fi
+  fi
+
+  if (( ${DRIVE_COUNT} % ${VOLUMES} != 0 )); then
+    echo "Drive count (${DRIVE_COUNT}) not divisible by number of volumes (${VOLUMES}), using VOLUMES=1"
+    VOLUMES=1
+  fi
+}
+
+create_volumes() {
+  FSTAB=()
+
+  umount /dev/md[0-9]* || true
+
+  umount ${DRIVES[*]} || true
+
+  mdadm --stop /dev/md[0-9]* || true
+
+  mdadm --zero-superblock ${DRIVES[*]}
+
+  for VOLUME in $(seq $VOLUMES); do
+    DPV=$(expr "$DRIVE_COUNT" "/" "$VOLUMES")
+    DRIVE_SET=($(ls ${DRIVE_PATTERN} | head -n $(expr "$DPV" "*" "$VOLUME") | tail -n "$DPV"))
+
+    mdadm --create /dev/md${VOLUME} --run --level 0 --chunk 256K --raid-devices=${#DRIVE_SET[@]} ${DRIVE_SET[*]}
+
+    mkfs.xfs -f /dev/md${VOLUME}
+
+    mkdir -p /data${VOLUME}
+
+    FSTAB+="/dev/md${VOLUME}  /data${VOLUME}  xfs rw,noatime,inode64,allocsize=16m  0 0\n"
+  done
+
+  mdadm --detail --scan > /etc/mdadm.conf
+
+  for DRIVE in ${DRIVES[*]}; do
+    sed -i -r "s|^${DRIVE}.+$||" /etc/fstab
+  done
+
+  sed -i -e "/$FSTAB_HEAD/,/$FSTAB_TAIL/d" /etc/fstab
+  echo "$FSTAB_HEAD" >> /etc/fstab
+  echo -e "${FSTAB[@]}" >> /etc/fstab
+  echo "$FSTAB_TAIL" >> /etc/fstab
+
+  mount -a
+}
+
+main "$@"

--- a/bootstrap-scripts/After_AMI_creation/madlib_install.sh
+++ b/bootstrap-scripts/After_AMI_creation/madlib_install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+##############################################
+# Prerequisite: a password-less sudo account #
+##############################################
+
+# Display command before executing
+set -o xtrace
+
+source /usr/local/greenplum-db/greenplum_path.sh
+MADLIB_PKG=`find . -name madlib*.tar.gz`
+tar -zxvf $MADLIB_PKG
+MADLIB=`find . -name madlib*.gppkg`
+gppkg -i $MADLIB
+$GPHOME/madlib/bin/madpack install -s madlib -p greenplum -c gpadmin@mdw:5432/postgres

--- a/bootstrap-scripts/After_AMI_creation/passwordless_setup.sh
+++ b/bootstrap-scripts/After_AMI_creation/passwordless_setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Prerequisite: a password-less sudo account
+
+# Display command before executing
+set -o xtrace
+
+
+echo y|ssh-keygen -t rsa -P "" -f ~/.ssh/id_rsa
+cat /home/gpadmin/.ssh/id_rsa.pub >> /home/gpadmin/.ssh/authorized_keys
+
+while IFS= read -r line; do
+	IFS=' ' read -r -a array <<< "$line"
+	if [  "${array[1]}" != `hostname` ]; then
+		echo -e "\e[33m*** Setting passwordless ssh between `hostname` to ${array[1]} ***\e[0m"
+		/usr/bin/expect << EOF
+		set timeout 30
+		spawn ssh-copy-id -i /home/gpadmin/.ssh/id_rsa.pub ${array[1]}
+		expect {
+			"(yes/no)" {send "yes\r"; exp_continue}
+			"password:" {send "gpadmin\r"}
+		}
+		expect eof
+EOF
+    fi
+done < ${IP_HOSTS_MAPPING}

--- a/bootstrap-scripts/After_AMI_creation/sshd_config.sh
+++ b/bootstrap-scripts/After_AMI_creation/sshd_config.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+##############################################
+# Prerequisite: a password-less sudo account #
+##############################################
+
+# Display command before executing
+set -o xtrace
+
+sed -i 's/^#\{0,1\}PubkeyAuthentication.*/PubkeyAuthentication yes/g' /etc/ssh/sshd_config
+sed -i 's/^#\{0,1\}PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+
+service sshd restart

--- a/bootstrap-scripts/After_AMI_creation/sshd_reset.sh
+++ b/bootstrap-scripts/After_AMI_creation/sshd_reset.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+##############################################
+# Prerequisite: a password-less sudo account #
+##############################################
+
+# Display command before executing
+set -o xtrace
+
+sed -i 's/^#\{0,1\}PasswordAuthentication.*/PasswordAuthentication no/g' /etc/ssh/sshd_config
+
+service sshd restart

--- a/bootstrap-scripts/Before_AMI_creation/aws_tools_setup.sh
+++ b/bootstrap-scripts/Before_AMI_creation/aws_tools_setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+##############################################
+# Prerequisite: a password-less sudo account #
+##############################################
+
+# display command before executing
+set -o xtrace
+
+# install aws-cfn-bootstrap
+easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+#curl -O https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+#tar -zxvf aws-cfn-bootstrap*.tar.gz
+#cd aws-cfn-bootstrap-*/ && python setup.py install && cd ..
+
+curl -O https://bootstrap.pypa.io/get-pip.py
+python get-pip.py
+pip install awscli

--- a/bootstrap-scripts/Before_AMI_creation/download.sh
+++ b/bootstrap-scripts/Before_AMI_creation/download.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# List All keys under ${bucket_name}
+# Download all packages,scripts,blueprints
+# Download all files under a given $release_name
+curl https://s3.amazonaws.com/${bucket_name}/ | \
+grep -oE '<Key>[^<]*(\/[^<]+)+<\/Key>' | \
+sed -e 's/<[^>]*>//g' |  \
+while read key; do
+    if [[ ${key} == ${packages_sub_dir}* && -n ${packages_sub_dir} ]]
+    then
+        echo "${key} matched ${packages_sub_dir}! Downloading..."
+        curl -O https://s3.amazonaws.com/${bucket_name}/${key} --fail || exit 1
+    elif [[ ${key} == ${scripts_sub_dir}* && -n ${scripts_sub_dir} ]]
+    then
+        echo "${key} matched ${scripts_sub_dir}! Downloading..."
+        curl -O https://s3.amazonaws.com/${bucket_name}/${key} --fail || exit 1
+    else
+        echo "No idea what ${key} is. Skipped"
+    fi
+done

--- a/bootstrap-scripts/Before_AMI_creation/download_piv_net.sh
+++ b/bootstrap-scripts/Before_AMI_creation/download_piv_net.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Download binaries from network.pivotal.io using the provided token
+if [ "$release_name" == "4.3.9.1" ] ;
+then
+	echo "inside if"
+	curl -f -o greenplum-db.zip -d "" -H "Authorization: Token ${pivnet_access_token}" -L https://network.pivotal.io/api/v2/products/pivotal-gpdb/releases/2146/product_files/5948/download
+#	curl -f -o greenplum-cc.zip -d "" -H "Authorization: Token rL1NeFhzsDFHopeCB3r1" -L https://network.pivotal.io/api/v2/products/pivotal-gpdb/releases/2146/product_files/6225/download
+	curl -f -o greenplum-cc.zip -d "" -H "Authorization: Token rL1NeFhzsDFHopeCB3r1" -L https://network.pivotal.io/api/v2/products/pivotal-gpdb/releases/2146/product_files/3191/download
+fi
+
+# If binary file not found, try downloading using a fallback token and version 4.3.9.1
+if [ ! -f greenplum-db.zip ] || [ ! -f greenplum-cc.zip ] ;
+then
+	echo "inside else if"
+	curl -f -o greenplum-db.zip -d "" -H "Authorization: Token rL1NeFhzsDFHopeCB3r1" -L https://network.pivotal.io/api/v2/products/pivotal-gpdb/releases/2146/product_files/5948/download
+#	curl -f -o greenplum-cc.zip -d "" -H "Authorization: Token rL1NeFhzsDFHopeCB3r1" -L https://network.pivotal.io/api/v2/products/pivotal-gpdb/releases/2146/product_files/6225/download
+	curl -f -o greenplum-cc.zip -d "" -H "Authorization: Token rL1NeFhzsDFHopeCB3r1" -L https://network.pivotal.io/api/v2/products/pivotal-gpdb/releases/2146/product_files/3191/download
+else
+	echo "Could not download required softwares. Abort!"
+fi

--- a/bootstrap-scripts/Before_AMI_creation/gpdb_install.sh
+++ b/bootstrap-scripts/Before_AMI_creation/gpdb_install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+##############################################
+# Prerequisite: a password-less sudo account #
+##############################################
+
+# Display command before executing
+set -o xtrace
+
+echo "Running GPDB installer"
+unzip greenplum-db*.zip
+
+GREENPLUM_DB=`find . -name greenplum-db*.bin`
+chmod a+x ${GREENPLUM_DB}
+echo -e "yes\n\nyes\nyes\n" | MORE=-1000 sh ${GREENPLUM_DB}
+chown -R gpadmin:gpadmin /usr/local/greenplum-db*
+chmod -R 777 /usr/local/greenplum-db*

--- a/bootstrap-scripts/Before_AMI_creation/linux_configuration.sh
+++ b/bootstrap-scripts/Before_AMI_creation/linux_configuration.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+##############################################
+# Prerequisite: a password-less sudo account #
+##############################################
+
+# display command before executing
+set -o xtrace
+
+# disable the need for a tty when running sudo
+sed -i '/Defaults[[:space:]]\+!*requiretty/s/^/#/' /etc/sudoers
+
+
+
+# disable SELinux
+setenforce 0
+if test -f /etc/selinux/config; then
+    sed -i s/SELINUX=enforcing/SELINUX=disabled/ /etc/selinux/config
+fi
+if test -f /selinux/enforce; then
+   echo 0 > /selinux/enforce
+fi
+
+
+
+# turn off iptables and ip6tables
+if test -f /etc/init.d/iptables; then
+    /etc/init.d/iptables save
+    /etc/init.d/iptables stop
+fi
+if test -f /etc/init.d/ip6tables; then
+    /etc/init.d/ip6tables save
+    /etc/init.d/ip6tables stop
+fi
+# persist the config
+chkconfig iptables off
+chkconfig ip6tables off
+service iptables stop
+service ip6tables stop
+
+
+
+# start ntpd on boot
+service ntpd start
+service ntpd status
+chkconfig ntpd on
+
+
+
+# Disable Transparent Huge Pages THP
+if test -f /sys/kernel/mm/transparent_hugepage/enabled; then
+   echo never > /sys/kernel/mm/transparent_hugepage/enabled
+fi
+if test -f /sys/kernel/mm/transparent_hugepage/defrag; then
+   echo never > /sys/kernel/mm/transparent_hugepage/defrag
+fi
+# Make THP disable persist across reboot
+cat << EOF >> /etc/rc.d/rc.local
+if test -f /sys/kernel/mm/transparent_hugepage/enabled; then
+   echo never > /sys/kernel/mm/transparent_hugepage/enabled
+fi
+if test -f /sys/kernel/mm/transparent_hugepage/defrag; then
+   echo never > /sys/kernel/mm/transparent_hugepage/defrag
+fi
+EOF
+
+
+
+# linux.sysctl settings
+cat<<EOF >> /etc/sysctl.conf
+###### Newly Added ######
+kernel.shmmax = 500000000
+kernel.shmmni = 4096
+kernel.shmall = 4000000000
+kernel.sem = 250 512000 100 2048
+kernel.sysrq = 1
+kernel.core_uses_pid = 1
+kernel.msgmnb = 65536
+kernel.msgmax = 65536
+kernel.msgmni = 2048
+net.ipv4.tcp_syncookies = 1
+net.ipv4.ip_forward = 0
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv4.tcp_tw_recycle = 1
+net.ipv4.tcp_max_syn_backlog = 4096
+net.ipv4.conf.all.arp_filter = 1
+net.ipv4.ip_local_port_range = 1025 65535
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+net.core.netdev_max_backlog = 10000
+net.core.rmem_max = 2097152
+net.core.wmem_max = 2097152
+vm.overcommit_memory = 2
+EOF
+# become effective immediately
+sysctl -p
+
+
+
+# linux.sysctl settings
+cat<<EOF >> /etc/security/limits.conf
+###### Newly Added ######
+* soft nofile 65536
+* hard nofile 65536
+* soft nproc 131072
+* hard nproc 131072
+EOF
+# For RedHat Enterprise Linux 6.x and CentOS 6.x, 
+# parameter values in the /etc/security/limits.d/90-nproc.conf 
+# file override the values in the limits.conf file. 
+# If a parameter value is set in both conf files, ensure that the 
+# parameter is set properly in the 90-nproc.conf file. 
+# The Linux module pam_limits sets user limits by reading the 
+# values from the limits.conf file and then from the 90-nproc.conf file. 
+# For information about PAM and user limits, 
+# see the documentation on PAM and pam_limits.
+cat<<EOF >> /etc/security/limits.d/90-nproc.conf
+###### Newly Added ######
+* soft nofile 65536
+* hard nofile 65536
+* soft nproc 131072
+* hard nproc 131072
+EOF
+
+
+
+# The Linux disk I/O scheduler for disk access supports different policies, 
+# such as CFQ, AS, and deadline.
+# Greenplum recommends the following scheduler option: deadline.
+for BLOCKDEV in /sys/block/*/queue/scheduler; do
+    echo deadline > "$BLOCKDEV"
+done
+# You can specify the I/O scheduler at boot time with the elevator kernel parameter. 
+# Add the parameter elevator=deadline to the kernel command in the file /boot/grub/grub.conf, 
+# the GRUB boot loader configuration file.
+sed -i -r "s/kernel(.+)/kernel\1 elevator=deadline transparent_hugepage=never/" /boot/grub/grub.conf

--- a/bootstrap-scripts/Before_AMI_creation/linux_software_setup.sh
+++ b/bootstrap-scripts/Before_AMI_creation/linux_software_setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+##############################################
+# Prerequisite: a password-less sudo account #
+##############################################
+
+# Display command before executing
+set -o xtrace
+
+# Clean yum cache
+yum clean all
+yum update -y
+yum install -y xfsprogs mdadm unzip ed ntp postgresql time bc vim
+yum groupinstall -y "Development Tools"
+yum -y install expect gcc-gfortran gcc-c++ scp unzip tar mlocate httpd ntp ntpd sshpass
+# Create or update the database used by locate
+updatedb

--- a/bootstrap-scripts/README.md
+++ b/bootstrap-scripts/README.md
@@ -1,0 +1,5 @@
+# After_AMI_creation
+These are the scripts that should be under /opt/pivotal shipped with the new AMI
+
+# Before_AMI_creation
+These are the scripts that should run already before Creating new AMI


### PR DESCRIPTION
@skahler-pivotal 

Added all scripts we used for preparing/installing/optimizing gpdb in AWS through AWS Cloudformation. Madlib 1.9.1 and gpcc 2.4 included.

The scripts are organized into two parts:
1 Scripts needed at runtime(ssh connections, gpinint, madlib/gpcc installation,etc). These scripts should be available under /opt/pivotal and shipped with AMI.

2 Scripts used for preparing an AWS AMI, including gpdb installations, linux kernel settings, linux softwares setup,etc.

We can review these scripts one by one sometime and make it solid. :)